### PR TITLE
BLOCKER bug when reading certificates

### DIFF
--- a/kubemq-java-sdk/src/main/java/io/kubemq/sdk/basic/GrpcClient.java
+++ b/kubemq-java-sdk/src/main/java/io/kubemq/sdk/basic/GrpcClient.java
@@ -111,7 +111,7 @@ public class GrpcClient {
             getLogger().info(MessageFormat.format("constructing channel to KubeMQ on {0}", kubemqAddress));
         }
 
-        if (StringUtils.isBlank(clientCertFile)) {
+        if (!StringUtils.isBlank(clientCertFile)) {
             return NettyChannelBuilder.forTarget(kubemqAddress)
                     .sslContext(
                             GrpcSslContexts


### PR DESCRIPTION
Expected:
- When NOT defining a certificate, no SSLContext should be defined.
Result:
```
Exception in thread "main" java.lang.IllegalArgumentException: File does not contain valid certificates:
	at io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder.trustManager(SslContextBuilder.java:192)
	at io.kubemq.sdk.basic.GrpcClient.constructChannel(GrpcClient.java:119)
	at io.kubemq.sdk.basic.GrpcClient.GetKubeMQClient(GrpcClient.java:68)
	at io.kubemq.sdk.event.lowlevel.Sender.SendEvent(Sender.java:70)
```