### PR TITLE
add: option to configure keepalive time

### DIFF
--- a/kubemq-java-sdk/src/main/java/io/kubemq/sdk/basic/ConfigurationLoader.java
+++ b/kubemq-java-sdk/src/main/java/io/kubemq/sdk/basic/ConfigurationLoader.java
@@ -56,6 +56,13 @@ class ConfigurationLoader {
     private static String _cert = null;
 
     /**
+     * static cache variable to store the gRPC KubeMQKeepAliveSeconds
+     * this is useful when the kubemq server is behind a load balancer
+     * that times out long lived inactive connections
+     */
+    private static String _keepaliveSeconds = null;
+
+    /**
      * Get KubeMQ Server Address by priority:
      * 1. Environment Variable (KubeMQServerAddress)
      * 2. Java Property (by passing the -DKubeMQServerAddress= option to the JVM)
@@ -104,6 +111,28 @@ class ConfigurationLoader {
         }
 
         return _key;
+    }
+
+/**
+     * Get the KubeMQ keep alive interval from environment variable or from Java property
+     *
+     * @return KubeMQ gRPC server keep alive time or empty string if can't be determined
+     * @apiNote The result is cached after the function is called once
+     */
+    static String GetKeepAliveSeconds() {
+        if (_keepaliveSeconds != null) return _keepaliveSeconds;
+
+        _keepaliveSeconds = GetFromEnvironmentVariable("KubeMQKeepAliveSeconds");
+
+        if (StringUtils.isNotBlank(_keepaliveSeconds)) return _keepaliveSeconds;
+
+        _keepaliveSeconds = GetFromProperty("keepaliveSeconds");
+
+        if (StringUtils.isBlank(_keepaliveSeconds)) {
+            _keepaliveSeconds = "";
+        }
+
+        return _keepaliveSeconds;
     }
 
     /**


### PR DESCRIPTION
In certain cases when KubeMQ is configured behind a load balancer the connections may get dropped by the LB if nothing is received for a period of time. Adding a configurable keep alive will help alleviate this issue. By default it is disabled.